### PR TITLE
Changed project to work with unity debug player debugging via VS

### DIFF
--- a/Autopilot-Common/Autopilot-Common.csproj
+++ b/Autopilot-Common/Autopilot-Common.csproj
@@ -65,7 +65,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
@@ -123,9 +123,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Defaults.dat" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Attributes\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Autopilot-Console/Autopilot-Console.csproj
+++ b/Autopilot-Console/Autopilot-Console.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>TRACE;DEBUG;</DefineConstants>

--- a/Autopilot/Autopilot.cs
+++ b/Autopilot/Autopilot.cs
@@ -2,6 +2,7 @@
 using FSControl;
 using Modules;
 using UnityEngine;
+using System.IO;
 namespace Autopilot
 {
     public class Autopilot : MonoBehaviour
@@ -196,7 +197,9 @@ namespace Autopilot
         //It's nice to identify in the log where things came from
         public static void Log(string text)
         {
-            Debug.Log($"{Time.realtimeSinceStartup} [Autopilot] {text}");
+            // Unity didn't like this
+            // Debug.Log($"{Time.realtimeSinceStartup} [Autopilot] {text}");
+            Debug.Log($"[Autopilot] {text}");
         }
     }
 }

--- a/Autopilot/Autopilot.csproj
+++ b/Autopilot/Autopilot.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>TRACE;DEBUG;</DefineConstants>


### PR DESCRIPTION
## Problem
I was unable to connect the debugger to the project in unity

## Changes
In order to be able to load the symbols the project had to be changed to generate portable debugging symbols instead of full. 

This  change allows one to break into the DLL using the unity debug player's debugging functionality within Visual Studio.

## Potential Issues
The logging file really does not like calling `Time.realtimeSinceStartup` outside of the main thread, so I commented this out